### PR TITLE
Fix for issue #284

### DIFF
--- a/src/main/java/epicsquid/mysticalworld/events/DamageHandler.java
+++ b/src/main/java/epicsquid/mysticalworld/events/DamageHandler.java
@@ -22,7 +22,10 @@ public class DamageHandler {
         if (trueAttacker instanceof EntityLivingBase) {
           if (((EntityLivingBase) trueAttacker).isEntityUndead()) {
             EntityPlayer player = (EntityPlayer) target;
-            float blessedAmount = (float) player.getAttributeMap().getAttributeInstance(ModModifiers.BLESSED).getAttributeValue();
+            float blessedAmount = 0;
+            try { //Handles fake players who do not have blesses attribute (Ex: LittleMaidMob)
+              blessedAmount = (float) player.getAttributeMap().getAttributeInstance(ModModifiers.BLESSED).getAttributeValue();
+            } catch (NullPointerException ignored) {}
             if (blessedAmount > 0) {
               trueAttacker.attackEntityFrom(DamageSource.ON_FIRE, blessedAmount);
             }


### PR DESCRIPTION
Try catch for Null Pointer Exception that would occur when an attribute is not part of the attribute map.
Fixes issues with LittleMaidMob